### PR TITLE
fix flaky testSerialize

### DIFF
--- a/archetype-common/src/test/java/com/kelin/archetype/common/json/JsonConverterTest.kt
+++ b/archetype-common/src/test/java/com/kelin/archetype/common/json/JsonConverterTest.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.kelin.archetype.beans.rest.RestResponse
 import com.kelin.archetype.test.KtTestUtils
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * @author Kelin Tan
@@ -13,10 +14,16 @@ import org.junit.jupiter.api.Test
 class JsonConverterTest : KtTestUtils {
     @Test
     fun testSerialize() {
-        JsonConverter.serialize(TestObject().apply {
+        val json = JsonConverter.serialize(TestObject().apply {
             id = 1
             name = "test"
-        }) eq """{"id":1,"name":"test"}"""
+        })
+
+        val expectedJson1 = """{"id":1,"name":"test"}"""
+        val expectedJson2 = """{"name":"test","id":1}"""
+
+        // Check if the JSON matches either variation
+        assertTrue(json == expectedJson1 || json == expectedJson2)
     }
 
     @Test


### PR DESCRIPTION
## PR Overview

The PR proposes a fix for the following tests -
[com.kelin.archetype.common.json.JsonConverterTest.testSerialize](https://github.com/KelinTan/spring-boot-archetype/blob/e4282acc9d4f94d0e9be44301222ecf3a5e29c5f/archetype-common/src/test/java/com/kelin/archetype/common/json/JsonConverterTest.kt#L15)

## Test Overview
The `testSerialize()` function converts a JSON into the stringified version of itself and checks whether it is equal to its expected value. In order to run this test, I had used the following commands -
- To build the project :
```
./gradle build +x test
```
- To run the test :
```
./gradlew --info archetype-common:test --tests=com.kelin.archetype.common.json.JsonConverterTest.testSerialize
```
- To run the nondex tool on this test :
```
./gradlew --info archetype-common:nondexTest --tests=com.kelin.archetype.common.json.JsonConverterTest.testSerialize
```
## Problem 
This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC
https://github.com/KelinTan/spring-boot-archetype/blob/e4282acc9d4f94d0e9be44301222ecf3a5e29c5f/archetype-common/src/test/java/com/kelin/archetype/common/json/JsonConverterTest.kt#L15-L21
When `testSerialize()` tries to seriliaze/stringify the predefined value in it, It uses the function to test `JsonConverter.serialize()` to convert the JSON to string. This function in turns uses `writeValueAsString()` which uses Jackson ObjectMapper() underneath it and it does not maintain the order of insertion when it converts the JSON into string. 
This means for the folllowing input json 
```
{id : 1, name : "test"}
```
The output can be either 
```
{id : 1, name : "test"}
```

```
{name : "test", id : 1}
```
The possibility of having two outputs for one input allows the test to fail when running the nondex tool

## Fix:
The proposed fix simply compares with the second variation from the serialisation for the following reasons:
- The test has only two values in the JSON
- The test uses a library and changing that would create more code changes and also possibly affect the notion of having the test in the first place (which is to compare serialised json values)
https://github.com/anirudh711/spring-boot-archetype/blob/2888c13126f16ef086309df29878f98649c2eca8/archetype-common/src/test/java/com/kelin/archetype/common/json/JsonConverterTest.kt#L16-L27